### PR TITLE
Handle FK constraint error on product deletion

### DIFF
--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -55,6 +55,11 @@ exports.remove = async (req, res, next) => {
     await item.destroy();
     res.status(204).end();
   } catch (err) {
+    if (err.name === 'SequelizeForeignKeyConstraintError') {
+      err.status = 409;
+      err.message =
+        'Produkt kann nicht gelöscht werden, da noch Bestellpositionen darauf verweisen.';
+    }
     next(err);
   }
 };


### PR DESCRIPTION
## Summary
- return 409 and meaningful message when product deletion fails due to foreign key constraint

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689ed69b3300832a9452857f0ce70a8c